### PR TITLE
exe path issue

### DIFF
--- a/mt-comp-test/comp-lbzip2.sh
+++ b/mt-comp-test/comp-lbzip2.sh
@@ -55,7 +55,7 @@ fi
 #echo $arc
 [ -f $ARC ] || { echo file "$ARC" not found; exit 1; }
 
-PAK=lbzip2
+PAK=./lbzip2
 EXT=.bz2
 OPTS=-u
 OPT_TH=-n

--- a/mt-comp-test/dec-lbzip2.sh
+++ b/mt-comp-test/dec-lbzip2.sh
@@ -48,7 +48,7 @@ max()
 
 [ -f $ARCHIVE ] || { echo file "$ARCHIVE" not found; exit 1; }
 
-PAK=lbzip2
+PAK=./lbzip2
 EXT=.bz2
 OPTS=
 OPT_TH=-n


### PR DESCRIPTION
Most nixes don't search current directory by default so it needs to use direct path (./exe).