### PR TITLE
use default block sizes

### DIFF
--- a/mt-comp-test/comp-pbzip2.sh
+++ b/mt-comp-test/comp-pbzip2.sh
@@ -57,7 +57,7 @@ fi
 
 PAK=./pbzip2
 EXT=.bz2
-OPTS=-b672
+OPTS=-b84
 OPT_TH=-p
 LEVELS="1 5 9"
 REPS=1

--- a/mt-comp-test/comp-plzip.sh
+++ b/mt-comp-test/comp-plzip.sh
@@ -57,7 +57,7 @@ fi
 
 PAK=./plzip
 EXT=.lz
-OPTS=-B64MiB
+OPTS=
 OPT_TH=-n
 LEVELS="0 6 9"
 REPS=1
@@ -65,6 +65,7 @@ REPS=1
 for lv in $LEVELS; do
     echo "## $PAK -$lv"
     echo
+
     for ((th=1; th<=$THREADS; th++)); do
         CMD="$PAK -$lv $OPTS $OPT_TH$th -f -c $ARC > $NULLDEV"
         REPS=`max $(reps_lv $lv) $(reps_th $th)`
@@ -76,6 +77,7 @@ for lv in $LEVELS; do
         sleepts
     done # for th;
 
+    if [ $lv -eq 9 ]; then OPTS="$OPTS -B32MiB"; fi
     CMD="$PAK -$lv $OPTS $OPT_TH$th -f -c $ARC > $ARC$EXT-$lv"
     eval $CMD
 done # for lv;

--- a/mt-comp-test/comp-zstdmt.sh
+++ b/mt-comp-test/comp-zstdmt.sh
@@ -57,7 +57,7 @@ fi
 
 PAK=./zstd-mt
 EXT=.zst
-OPTS= #-b64
+OPTS=
 OPT_TH=-T
 LEVELS="1 12 19"
 REPS=1


### PR DESCRIPTION
Bigger blocks don't give much better compression but make decompression not smooth, in relation to number of threads.